### PR TITLE
fix: use defined --accent variable for scroll progress bar

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -562,14 +562,36 @@ details[open] summary {
 
 pre {
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* Long unbreakable strings (e.g. URLs) in user-generated content must wrap
-   instead of forcing the page into horizontal scroll. */
+   instead of forcing the page into horizontal scroll. Applied to descendants
+   too because some elements (flex/inline-block children, nested blocks) can
+   establish their own min-content width that defeats inherited wrapping. */
 details > div,
-article > p,
-.user-about {
+details > div *,
+article,
+article * {
   overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+/* Constrain embedded media in user-generated content so wide images or
+   tables don't push the page into horizontal scroll. */
+details > div img,
+details > div video,
+article img,
+article video {
+  max-width: 100%;
+  height: auto;
+}
+
+details > div table,
+article table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 /* User profile page */

--- a/static/styles.css
+++ b/static/styles.css
@@ -2718,10 +2718,10 @@ details {
   content: '';
   position: absolute;
   inset: 0;
-  background: var(--accent-color);
+  background: var(--accent);
   transform-origin: left;
   transform: scaleX(0);
-  
+
   /* Link to scroll progress on the document */
   animation: progress-grow linear;
   animation-timeline: scroll(root);

--- a/static/styles.css
+++ b/static/styles.css
@@ -564,6 +564,14 @@ pre {
   white-space: pre-wrap;
 }
 
+/* Long unbreakable strings (e.g. URLs) in user-generated content must wrap
+   instead of forcing the page into horizontal scroll. */
+details > div,
+article > p,
+.user-about {
+  overflow-wrap: anywhere;
+}
+
 /* User profile page */
 .user-profile h1 {
   margin-bottom: 0.5em;


### PR DESCRIPTION
The reading progress indicator referenced var(--accent-color), which is
never defined in the stylesheet. The resolved background fell back to
transparent, making the scroll-driven progress bar invisible. Replace
with the actual --accent token so the bar grows as the user scrolls.